### PR TITLE
fix(eslint): add ESLint flat config for v9

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,36 @@
+import js from '@eslint/js';
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import reactPlugin from 'eslint-plugin-react';
+
+export default [
+  {
+    ignores: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/build/**',
+      '**/.turbo/**',
+      '**/.next/**',
+      'cli/bin/**',
+      '**/coverage/**'
+    ],
+  },
+  js.configs.recommended,
+  {
+    files: ['**/*.{ts,tsx,js,jsx}'],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2022,
+      sourceType: 'module',
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      react: reactPlugin,
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      'react/react-in-jsx-scope': 'off',
+    },
+    settings: { react: { version: 'detect' } },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepare": "husky install"
   },
   "devDependencies": {
+    "@eslint/js": "^9.8.0",
     "@types/node": "^20.11.30",
     "eslint": "^9.8.0",
     "eslint-plugin-react": "^7.34.3",


### PR DESCRIPTION
Adds root eslint.config.mjs and installs @eslint/js so CI lint can run with ESLint v9 flat config. Follow-up to PR #2 which merged before this commit was pushed.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/942d1af4-9aa9-464a-ab2d-1a653546d60c/task/6b718d2f-a7ea-44bc-9cf8-e3b39dcdab50))