### PR TITLE
fix(types): add @types/archiver and type error handler (codegen)

### DIFF
--- a/services/codegen/package.json
+++ b/services/codegen/package.json
@@ -20,6 +20,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/archiver": "^6.0.3",
     "@types/fs-extra": "^11.0.4",
     "tsx": "^4.11.0",
     "typescript": "^5.8.3"

--- a/services/codegen/src/generators/web.ts
+++ b/services/codegen/src/generators/web.ts
@@ -21,7 +21,7 @@ async function zipFolder(src: string, destZip: string) {
     const output = fs.createWriteStream(destZip);
     const archive = archiver("zip", { zlib: { level: 9 } });
     output.on("close", () => resolve());
-    archive.on("error", (err) => reject(err));
+    archive.on("error", (err: unknown) => reject(err as Error));
     archive.pipe(output);
     archive.directory(src, false);
     archive.finalize();


### PR DESCRIPTION
Fix typecheck failures after PR #4 merge by:\n- adding @types/archiver to services/codegen devDependencies\n- typing archiver error handler (no implicit any)\n\nThis should make CI typecheck pass.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/942d1af4-9aa9-464a-ab2d-1a653546d60c/task/6b718d2f-a7ea-44bc-9cf8-e3b39dcdab50))