### PR TITLE
fix(web): use postcss.config.mjs (ESM) to resolve Next build error

### DIFF
--- a/apps/web/postcss.config.mjs
+++ b/apps/web/postcss.config.mjs
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
Address 'module is not defined' by switching PostCSS config to ESM export (postcss.config.mjs).

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/942d1af4-9aa9-464a-ab2d-1a653546d60c/task/6b718d2f-a7ea-44bc-9cf8-e3b39dcdab50))